### PR TITLE
Update setup to clone into ~/Code and add missing formulae

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,17 +3,15 @@
 Dead simple script to setup my new Mac:
 
 ```shell
-cd ~/Downloads
-curl -sL https://raw.githubusercontent.com/infomofo/mac-setup-script/main/defaults.sh | bash
-curl -O https://raw.githubusercontent.com/infomofo/mac-setup-script/main/install.sh
-chmod +x install.sh
-./install.sh
+mkdir -p ~/Code
+git clone https://github.com/infomofo/mac-setup-script.git ~/Code/mac-setup-script
+cd ~/Code/mac-setup-script
+bash defaults.sh
+bash install.sh
 ```
 
 On a personal machine, also run:
 
 ```shell
-curl -O https://raw.githubusercontent.com/infomofo/mac-setup-script/main/install-personal.sh
-chmod +x install-personal.sh
-./install-personal.sh
+bash install-personal.sh
 ```

--- a/install-personal.sh
+++ b/install-personal.sh
@@ -10,6 +10,8 @@ personal_casks=(
   discord
   signal
   steam
+  the-unarchiver
+  vlc
 )
 
 personal_brews=(

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,9 @@ brews=(
   jq
   macvim        # https://macvim-dev.github.io/macvim/
   node
+  nvm
   python
+  yarn
   reattach-to-user-namespace
   shellcheck
   tmux


### PR DESCRIPTION
## Summary
- Clone mac-setup-script to `~/Code/mac-setup-script` (with `mkdir -p`) instead of `~/Downloads`
- Switch README from curl-pipe-bash to git clone workflow
- Add `nvm` and `yarn` to `install.sh` brews
- Add `the-unarchiver` and `vlc` to `install-personal.sh` casks

## Test plan
- [ ] Verify CI passes
- [ ] Fresh clone into `~/Code/mac-setup-script` works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)